### PR TITLE
Remove query from editor scripts

### DIFF
--- a/editor-script-cleanup/cleanup.editor_script
+++ b/editor-script-cleanup/cleanup.editor_script
@@ -27,9 +27,6 @@ function M.get_commands()
         {
             label="Remove Unused Images From Project",
             locations = {"Edit"},
-            query = {
-                selection = {type = "resource", cardinality = "one"}
-            },
             run = function(opts)
                 return {
                     {
@@ -42,9 +39,6 @@ function M.get_commands()
         {
             label="Remove Missing Images From Atlases",
             locations = {"Edit"},
-            query = {
-                selection = {type = "resource", cardinality = "one"}
-            },
             run = function(opts)
                 return {
                     {


### PR DESCRIPTION
I noticed you don't use query results for these commands, and since queries are optional, it is safe to remove them.